### PR TITLE
Collect error count per each error reason in `CsvFileInput`

### DIFF
--- a/jstests/noPassthrough/virtual/error_report.csv
+++ b/jstests/noPassthrough/virtual/error_report.csv
@@ -1,0 +1,9 @@
+string,number,long,double,boolean,oid,date
+holyMoly,34,1234567890,35.23,true,123456789012345678901234,2024-04-12T13:36:37.100-06:00
+Christopher Columbus,48,12345678901.2334,48.12,!true,objectid(123456789123456789),2024-04-11T13:34:34.343Z
+Backpack,55.12,33.33,45,incorrect,objectID("1029384756abcdeabcde"),2024-11-11T36:34:63.342Z
+Cannot,3000000000,99000000000000000000,33.4,true,"123456789123456789abcdef,2014-14-14
+smoking Hot,34,12345678901,GGang,boolean,"objectIDobjectIdobjectId",Not A Date Bro
+,-2900000000,-9323372036854775808,90.09,f,objectID("You think this is ID"),201708081111111Z
+Really Really Really Really Really Long String I mean Really Really Long,3,45,1.2,FALSE,objectid("884cdc3ef43ff10ca56e23fd"),Rizz
+Strong and Sound,23Catalog,9000000000,1345.232,yes

--- a/jstests/noPassthrough/virtual/error_report.txt
+++ b/jstests/noPassthrough/virtual/error_report.txt
@@ -1,0 +1,1 @@
+kString/string,number/int32,distant/int64,quadruple/double,RightOrWrong/bool,identifier/oid,signOn/date

--- a/jstests/noPassthrough/virtual/error_report2.csv
+++ b/jstests/noPassthrough/virtual/error_report2.csv
@@ -1,0 +1,5 @@
+Proxy Barracks,invalidNumber,34582,1.1,ture,oBjECtid("0987612345abcdef12345678"),2020-01-01T01:01:23.233Z
+Blink Stalkers,34,invalidLong,4.01,Y
+STEM,12,9393939393939393939393,11.1111,N,objectID("111111z1110000000000abcd"),2012-12-12T12:12:12.121Z
+Invasion,13.33,34444444,4.423,N,objectid("00000000003948576219abcd"),2017-04-23
+Distance of you,20,45,invalidDouble,TRUE,"abcdefabcdefabcdefabcdef",2000-03-03T03:03:03.333Z

--- a/jstests/noPassthrough/virtual/error_report3.csv
+++ b/jstests/noPassthrough/virtual/error_report3.csv
@@ -1,0 +1,4 @@
+error,number,one,is,not,6
+cash,flow,dollars,Christopher,5
+bottle,neck,34.23,double,5
+Columbus,90000000000,-9999999999999999999999,invalidDouble,incorrect,mismatch,7

--- a/jstests/noPassthrough/virtual/error_report_csv_file.js
+++ b/jstests/noPassthrough/virtual/error_report_csv_file.js
@@ -16,7 +16,7 @@ db.dropDatabase();
 
 const coll = db.ext_csv;
 
-(function CollectEachErrorCases() {
+(function collectEachErrorCases() {
     removeFile("/tmp/error_report.csv");
     copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report.csv", "/tmp/error_report.csv");
 

--- a/jstests/noPassthrough/virtual/error_report_csv_file.js
+++ b/jstests/noPassthrough/virtual/error_report_csv_file.js
@@ -16,11 +16,11 @@ db.dropDatabase();
 
 const coll = db.ext_csv;
 
-(function test1() {
+(function CollectEachErrorCases() {
     removeFile("/tmp/error_report.csv");
     copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report.csv", "/tmp/error_report.csv");
 
-    jsTestLog("Running Test1");
+    jsTestLog("Running CollectEachErrorCases Test");
     coll.drop();
     db.createCollection("ext_csv", {
         virtual: {
@@ -50,97 +50,36 @@ const coll = db.ext_csv;
               `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
 })();
 
-(function test2() {
+(function multipleCsvStreams() {
     removeFile("/tmp/error_report2.csv");
     copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report2.csv", "/tmp/error_report2.csv");
+    removeFile("/tmp/error_report3.csv");
+    copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report3.csv", "/tmp/error_report3.csv");
 
-    jsTestLog("Running Test2");
-    coll.drop();
-    db.createCollection("ext_csv", {
-        virtual: {
-            dataSources: [{url: "file://error_report2.csv", storageType: "file", fileType: "csv"}],
-            metadataUrl: "file://error_report.txt"
-        }
-    });
-
-    const expectedRecordStoreStats = {
-        "incompleteConversionToNumeric": NumberLong(1),
-        "invalidInt32": NumberLong(1),
-        "invalidInt64": NumberLong(1),
-        "invalidDouble": NumberLong(1),
-        "outOfRange": NumberLong(1),
-        "invalidDate": NumberLong(1),
-        "invalidOid": NumberLong(1),
-        "invalidBoolean": NumberLong(1),
-        "metadataAndDataDifferentLength": NumberLong(1),
-        "totalErrorCount": NumberLong(9)
-    };
-    const res = coll.explain("executionStats").find().finish();
-    const recordStoreStats = getPlanStage(res.executionStats.executionStages, "COLLSCAN");
-    assert.neq(null, recordStoreStats);
-    assert.eq(expectedRecordStoreStats,
-              recordStoreStats.recordStoreStats,
-              `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
-})();
-
-(function test3() {
-    jsTestLog("Running Test3");
+    jsTestLog("Running MultipleCsvStreams Test");
     coll.drop();
     db.createCollection("ext_csv", {
         virtual: {
             dataSources: [
                 {url: "file://error_report.csv", storageType: "file", fileType: "csv"},
-                {url: "file://error_report2.csv", storageType: "file", fileType: "csv"}
+                {url: "file://error_report2.csv", storageType: "file", fileType: "csv"},
+                {url: "file://error_report3.csv", storageType: "file", fileType: "csv"}
             ],
             metadataUrl: "file://error_report.txt"
         }
     });
 
     const expectedRecordStoreStats = {
-        "incompleteConversionToNumeric": NumberLong(5),
-        "invalidInt32": NumberLong(2),
-        "invalidInt64": NumberLong(2),
-        "invalidDouble": NumberLong(3),
-        "outOfRange": NumberLong(5),
-        "invalidDate": NumberLong(7),
-        "invalidOid": NumberLong(6),
-        "invalidBoolean": NumberLong(5),
-        "metadataAndDataDifferentLength": NumberLong(2),
-        "totalErrorCount": NumberLong(37)
-    };
-
-    const res = coll.explain("executionStats").find().finish();
-    const recordStoreStats = getPlanStage(res.executionStats.executionStages, "COLLSCAN");
-    assert.neq(null, recordStoreStats);
-    assert.eq(expectedRecordStoreStats,
-              recordStoreStats.recordStoreStats,
-              `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
-})();
-
-(function test4() {
-    removeFile("/tmp/error_report3.csv");
-    copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report3.csv", "/tmp/error_report3.csv");
-
-    jsTestLog("Running allErrorTest");
-    coll.drop();
-    db.createCollection("ext_csv", {
-        virtual: {
-            dataSources: [{url: "file://error_report3.csv", storageType: "file", fileType: "csv"}],
-            metadataUrl: "file://error_report.txt"
-        }
-    });
-
-    const expectedRecordStoreStats = {
-        "incompleteConversionToNumeric": NumberLong(1),
-        "invalidInt32": NumberLong(3),
-        "invalidInt64": NumberLong(2),
-        "invalidDouble": NumberLong(4),
-        "outOfRange": NumberLong(2),
-        "invalidDate": NumberLong(1),
-        "invalidOid": NumberLong(2),
-        "invalidBoolean": NumberLong(4),
-        "metadataAndDataDifferentLength": NumberLong(3),
-        "totalErrorCount": NumberLong(22)
+        "incompleteConversionToNumeric": NumberLong(6),
+        "invalidInt32": NumberLong(5),
+        "invalidInt64": NumberLong(4),
+        "invalidDouble": NumberLong(7),
+        "outOfRange": NumberLong(7),
+        "invalidDate": NumberLong(8),
+        "invalidOid": NumberLong(8),
+        "invalidBoolean": NumberLong(9),
+        "metadataAndDataDifferentLength": NumberLong(5),
+        "totalErrorCount": NumberLong(59)
     };
 
     const res = coll.explain("executionStats").find().finish();

--- a/jstests/noPassthrough/virtual/error_report_csv_file.js
+++ b/jstests/noPassthrough/virtual/error_report_csv_file.js
@@ -1,0 +1,154 @@
+/**
+ * Tests error report over virtual collections over external CSV file(s).
+ */
+
+import {
+    getPlanStage,
+} from "jstests/libs/analyze_plan.js";
+
+removeFile("/tmp/error_report.txt");
+copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report.txt", "/tmp/error_report.txt");
+
+const conn = MongoRunner.runMongod();
+
+const db = conn.getDB(jsTestName());
+db.dropDatabase();
+
+const coll = db.ext_csv;
+
+(function test1() {
+    removeFile("/tmp/error_report.csv");
+    copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report.csv", "/tmp/error_report.csv");
+
+    jsTestLog("Running Test1");
+    coll.drop();
+    db.createCollection("ext_csv", {
+        virtual: {
+            dataSources: [{url: "file://error_report.csv", storageType: "file", fileType: "csv"}],
+            metadataUrl: "file://error_report.txt"
+        }
+    });
+    const expectedRecordStoreStats = {
+        "incompleteConversionToNumeric": NumberLong(4),
+        "invalidInt32": NumberLong(1),
+        "invalidInt64": NumberLong(1),
+        "invalidDouble": NumberLong(2),
+        "outOfRange": NumberLong(4),
+        "invalidDate": NumberLong(6),
+        "invalidOid": NumberLong(5),
+        "invalidBoolean": NumberLong(4),
+        "metadataAndDataDifferentLength": NumberLong(1),
+        "totalErrorCount": NumberLong(28)
+    };
+    const res = coll.explain("executionStats")
+                    .find({"number": {$gte: 30}}, {kString: 1, number: 1, identifier: 1, signOn: 1})
+                    .finish();
+    const recordStoreStats = getPlanStage(res.executionStats.executionStages, "COLLSCAN");
+    assert.neq(null, recordStoreStats);
+    assert.eq(expectedRecordStoreStats,
+              recordStoreStats.recordStoreStats,
+              `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
+})();
+
+(function test2() {
+    removeFile("/tmp/error_report2.csv");
+    copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report2.csv", "/tmp/error_report2.csv");
+
+    jsTestLog("Running Test2");
+    coll.drop();
+    db.createCollection("ext_csv", {
+        virtual: {
+            dataSources: [{url: "file://error_report2.csv", storageType: "file", fileType: "csv"}],
+            metadataUrl: "file://error_report.txt"
+        }
+    });
+
+    const expectedRecordStoreStats = {
+        "incompleteConversionToNumeric": NumberLong(1),
+        "invalidInt32": NumberLong(1),
+        "invalidInt64": NumberLong(1),
+        "invalidDouble": NumberLong(1),
+        "outOfRange": NumberLong(1),
+        "invalidDate": NumberLong(1),
+        "invalidOid": NumberLong(1),
+        "invalidBoolean": NumberLong(1),
+        "metadataAndDataDifferentLength": NumberLong(1),
+        "totalErrorCount": NumberLong(9)
+    };
+    const res = coll.explain("executionStats").find().finish();
+    const recordStoreStats = getPlanStage(res.executionStats.executionStages, "COLLSCAN");
+    assert.neq(null, recordStoreStats);
+    assert.eq(expectedRecordStoreStats,
+              recordStoreStats.recordStoreStats,
+              `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
+})();
+
+(function test3() {
+    jsTestLog("Running Test3");
+    coll.drop();
+    db.createCollection("ext_csv", {
+        virtual: {
+            dataSources: [
+                {url: "file://error_report.csv", storageType: "file", fileType: "csv"},
+                {url: "file://error_report2.csv", storageType: "file", fileType: "csv"}
+            ],
+            metadataUrl: "file://error_report.txt"
+        }
+    });
+
+    const expectedRecordStoreStats = {
+        "incompleteConversionToNumeric": NumberLong(5),
+        "invalidInt32": NumberLong(2),
+        "invalidInt64": NumberLong(2),
+        "invalidDouble": NumberLong(3),
+        "outOfRange": NumberLong(5),
+        "invalidDate": NumberLong(7),
+        "invalidOid": NumberLong(6),
+        "invalidBoolean": NumberLong(5),
+        "metadataAndDataDifferentLength": NumberLong(2),
+        "totalErrorCount": NumberLong(37)
+    };
+
+    const res = coll.explain("executionStats").find().finish();
+    const recordStoreStats = getPlanStage(res.executionStats.executionStages, "COLLSCAN");
+    assert.neq(null, recordStoreStats);
+    assert.eq(expectedRecordStoreStats,
+              recordStoreStats.recordStoreStats,
+              `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
+})();
+
+(function test4() {
+    removeFile("/tmp/error_report3.csv");
+    copyFile(pwd() + "/jstests/noPassthrough/virtual/error_report3.csv", "/tmp/error_report3.csv");
+
+    jsTestLog("Running allErrorTest");
+    coll.drop();
+    db.createCollection("ext_csv", {
+        virtual: {
+            dataSources: [{url: "file://error_report3.csv", storageType: "file", fileType: "csv"}],
+            metadataUrl: "file://error_report.txt"
+        }
+    });
+
+    const expectedRecordStoreStats = {
+        "incompleteConversionToNumeric": NumberLong(1),
+        "invalidInt32": NumberLong(3),
+        "invalidInt64": NumberLong(2),
+        "invalidDouble": NumberLong(4),
+        "outOfRange": NumberLong(2),
+        "invalidDate": NumberLong(1),
+        "invalidOid": NumberLong(2),
+        "invalidBoolean": NumberLong(4),
+        "metadataAndDataDifferentLength": NumberLong(3),
+        "totalErrorCount": NumberLong(22)
+    };
+
+    const res = coll.explain("executionStats").find().finish();
+    const recordStoreStats = getPlanStage(res.executionStats.executionStages, "COLLSCAN");
+    assert.neq(null, recordStoreStats);
+    assert.eq(expectedRecordStoreStats,
+              recordStoreStats.recordStoreStats,
+              `Expected ${tojson(expectedRecordStoreStats)} but got ${tojson(res)}`);
+})();
+
+MongoRunner.stopMongod(conn);

--- a/src/mongo/db/exec/collection_scan.cpp
+++ b/src/mongo/db/exec/collection_scan.cpp
@@ -608,11 +608,15 @@ unique_ptr<PlanStageStats> CollectionScan::getStats() {
     }
 
     unique_ptr<PlanStageStats> ret = std::make_unique<PlanStageStats>(_commonStats, STAGE_COLLSCAN);
+    getSpecificStats();
     ret->specific = std::make_unique<CollectionScanStats>(_specificStats);
     return ret;
 }
 
 const SpecificStats* CollectionScan::getSpecificStats() const {
+    if (_cursor) {
+        _specificStats._recordStoreStats = _cursor->getStats();
+    }
     return &_specificStats;
 }
 

--- a/src/mongo/db/exec/plan_stats.h
+++ b/src/mongo/db/exec/plan_stats.h
@@ -295,6 +295,8 @@ struct CollectionScanStats : public SpecificStats {
 
     // The end location of a reverse scan and start location for a forward scan.
     boost::optional<RecordIdBound> maxRecord;
+
+    mutable boost::optional<BSONObj> _recordStoreStats;
 };
 
 struct CountStats : public SpecificStats {

--- a/src/mongo/db/query/plan_explainer_impl.cpp
+++ b/src/mongo/db/query/plan_explainer_impl.cpp
@@ -300,9 +300,7 @@ void statsToBSON(const PlanStageStats& stats,
         if (verbosity >= ExplainOptions::Verbosity::kExecStats) {
             bob->appendNumber("docsExamined", static_cast<long long>(spec->docsTested));
             if (spec->_recordStoreStats) {
-                bob->appendObject("recordStoreStats",
-                                  spec->_recordStoreStats->objdata(),
-                                  spec->_recordStoreStats->objsize());
+                bob->append("recordStoreStats", *(spec->_recordStoreStats));
             }
         }
     } else if (STAGE_COUNT == stats.stageType) {

--- a/src/mongo/db/query/plan_explainer_impl.cpp
+++ b/src/mongo/db/query/plan_explainer_impl.cpp
@@ -299,6 +299,11 @@ void statsToBSON(const PlanStageStats& stats,
         }
         if (verbosity >= ExplainOptions::Verbosity::kExecStats) {
             bob->appendNumber("docsExamined", static_cast<long long>(spec->docsTested));
+            if (spec->_recordStoreStats) {
+                bob->appendObject("recordStoreStats",
+                                  spec->_recordStoreStats->objdata(),
+                                  spec->_recordStoreStats->objsize());
+            }
         }
     } else if (STAGE_COUNT == stats.stageType) {
         CountStats* spec = static_cast<CountStats*>(stats.specific.get());

--- a/src/mongo/db/storage/csv_file.cpp
+++ b/src/mongo/db/storage/csv_file.cpp
@@ -54,7 +54,8 @@ CsvFileInput::CsvFileInput(const std::string& fileRelativePath,
                         fileRelativePath),
       _metadataAbsolutePath((externalFileDir == "" ? kDefaultFilePath : externalFileDir) +
                             metadataRelativePath),
-      _ifs() {
+      _ifs(),
+      _errorCount({}) {
     uassert(200000400,
             "File path must not include '..' but {} does"_format(_fileAbsolutePath),
             _fileAbsolutePath.find("..") == std::string::npos);
@@ -95,9 +96,10 @@ int CsvFileInput::doRead(char* data, int size) {
     }
 
     int nRead = bsonObj->objsize();
-    uassert(200000402,
+    tassert(200000402,
             "Buff Size {} bytes is too small to contain {} bytes bsonObj"_format(size, nRead),
             nRead <= size);
+
     memcpy(data, bsonObj->objdata(), nRead);
     return nRead;
 }
@@ -170,68 +172,99 @@ Metadata CsvFileInput::getMetadata(const std::vector<std::string>& header) {
     return ret;
 }
 
-template <CsvFieldType T>
-void appendTo(BSONObjBuilder& builder, const std::string& fieldName, const std::string& data);
 
 template <>
-void appendTo<CsvFieldType::kInt32>(BSONObjBuilder& builder,
-                                    const std::string& fieldName,
-                                    const std::string& data) {
-    int converted = stoi(data);
-    builder.append(fieldName, stoi(data));
-    if (data.find('.') != std::string::npos) {
-        LOGV2_WARNING(
-            200000405,
-            "{field}: Lossy conversion of double type to int32 type: {original} To {converted}",
-            "field"_attr = fieldName,
-            "original"_attr = data,
-            "convertedTo"_attr = converted);
+void CsvFileInput::appendTo<CsvFieldType::kInt32>(BSONObjBuilder& builder,
+                                                  const std::string& fieldName,
+                                                  const std::string& data) {
+    int converted;
+    size_t idx;
+    try {
+        converted = stoi(data, &idx);
+        builder.append(fieldName, converted);
+    } catch (std::invalid_argument e) {
+        _errorCount._invalidInt32++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    } catch (std::out_of_range e) {
+        _errorCount._outOfRange++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    }
+
+    if (idx != data.length()) {
+        _errorCount._incompleteConversionToNumeric++;
+        _errorCount._totalErrorCount++;
     }
 }
 
 template <>
-void appendTo<CsvFieldType::kDouble>(BSONObjBuilder& builder,
-                                     const std::string& fieldName,
-                                     const std::string& data) {
-    builder.append(fieldName, stod(data));
-}
-
-template <>
-void appendTo<CsvFieldType::kInt64>(BSONObjBuilder& builder,
-                                    const std::string& fieldName,
-                                    const std::string& data) {
-    long long int converted = stoll(data);
-    builder.append(fieldName, converted);
-    if (data.find('.') != std::string::npos) {
-        LOGV2_WARNING(200000406,
-                      "{field}: lossy conversion of decimal type to int64 type: {original} "
-                      "converted to {convertedTo}",
-                      "field"_attr = fieldName,
-                      "original"_attr = data,
-                      "convertedTo"_attr = converted);
+void CsvFileInput::appendTo<CsvFieldType::kDouble>(BSONObjBuilder& builder,
+                                                   const std::string& fieldName,
+                                                   const std::string& data) {
+    try {
+        builder.append(fieldName, stod(data));
+    } catch (std::invalid_argument e) {
+        _errorCount._invalidDouble++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
     }
 }
 
 template <>
-void appendTo<CsvFieldType::kString>(BSONObjBuilder& builder,
-                                     const std::string& fieldName,
-                                     const std::string& data) {
+void CsvFileInput::appendTo<CsvFieldType::kInt64>(BSONObjBuilder& builder,
+                                                  const std::string& fieldName,
+                                                  const std::string& data) {
+    long long int converted;
+    size_t idx;
+    try {
+        converted = stoll(data, &idx);
+        builder.append(fieldName, converted);
+    } catch (std::invalid_argument e) {
+        _errorCount._invalidInt64++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    } catch (std::out_of_range e) {
+        _errorCount._outOfRange++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    }
+
+    if (idx != data.length()) {
+        _errorCount._incompleteConversionToNumeric++;
+        _errorCount._totalErrorCount++;
+    }
+}
+
+template <>
+void CsvFileInput::appendTo<CsvFieldType::kString>(BSONObjBuilder& builder,
+                                                   const std::string& fieldName,
+                                                   const std::string& data) {
     builder.append(fieldName, data);
 }
 
 template <>
-void appendTo<CsvFieldType::kDate>(BSONObjBuilder& builder,
-                                   const std::string& fieldName,
-                                   const std::string& data) {
+void CsvFileInput::appendTo<CsvFieldType::kDate>(BSONObjBuilder& builder,
+                                                 const std::string& fieldName,
+                                                 const std::string& data) {
     auto date = dateFromISOString(data);
-    uassert(date.getStatus().code(), date.getStatus().toString(), date.isOK());
+    if (!date.isOK()) {
+        _errorCount._invalidDate++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    }
     builder.appendDate(fieldName, date.getValue());
 }
 
 template <>
-void appendTo<CsvFieldType::kOid>(BSONObjBuilder& builder,
-                                  const std::string& fieldName,
-                                  const std::string& data) {
+void CsvFileInput::appendTo<CsvFieldType::kOid>(BSONObjBuilder& builder,
+                                                const std::string& fieldName,
+                                                const std::string& data) {
     constexpr size_t kLengthOidValue = 24;
     constexpr size_t kOidTypeStr = 8;                      // Length of 'objectid'.
     constexpr size_t kOidTypeStrPrefix = kOidTypeStr + 2;  // Length of 'objectid(\"'.
@@ -240,25 +273,40 @@ void appendTo<CsvFieldType::kOid>(BSONObjBuilder& builder,
     if (data[0] == 'O' || data[0] == 'o') {
         std::transform(
             mutableData.begin(), mutableData.begin() + kOidTypeStr, mutableData.begin(), ::tolower);
-        uassert(ErrorCodes::BadValue,
-                "Invalid Object Id format: {}"_format(data),
-                mutableData.substr(0, kOidTypeStrPrefix) == "objectid(\"");
+
+        if (mutableData.substr(0, kOidTypeStrPrefix) != "objectid(\"") {
+            _errorCount._invalidOid++;
+            _errorCount._totalErrorCount++;
+            builder.appendNull(fieldName);
+            return;
+        }
+
         mutableData = mutableData.substr(kOidTypeStrPrefix, kLengthOidValue);
     } else if (data[0] == '\"') {
         mutableData = mutableData.substr(1, kLengthOidValue);
     }
 
-    uassert(ErrorCodes::BadValue,
-            "Invalid Object Id Format: {}"_format(data),
-            mutableData.length() == kLengthOidValue);
-    mongo::OID id = mongo::OID(mutableData);  // Throws exception if it detects bad OID.
-    builder.append(fieldName, id);
+    if (mutableData.length() != kLengthOidValue) {
+        _errorCount._invalidOid++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    }
+
+    try {
+        mongo::OID id = mongo::OID(mutableData);  // Throws exception if it detects bad OID.
+        builder.append(fieldName, id);
+    } catch (ExceptionFor<ErrorCodes::FailedToParse> e) {
+        _errorCount._invalidOid++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+    }
 }
 
 template <>
-void appendTo<CsvFieldType::kBool>(BSONObjBuilder& builder,
-                                   const std::string& fieldName,
-                                   const std::string& data) {
+void CsvFileInput::appendTo<CsvFieldType::kBool>(BSONObjBuilder& builder,
+                                                 const std::string& fieldName,
+                                                 const std::string& data) {
     std::string mutableData = data;
     bool val;
     std::transform(data.begin(), data.end(), mutableData.begin(), ::tolower);
@@ -268,8 +316,12 @@ void appendTo<CsvFieldType::kBool>(BSONObjBuilder& builder,
     else if (mutableData == "false" || mutableData == "f" || mutableData == "no" ||
              mutableData == "n" || mutableData == "0")
         val = false;
-    else
-        uasserted(ErrorCodes::BadValue, "{} is an invalid Boolean representation"_format(data));
+    else {
+        _errorCount._invalidBoolean++;
+        _errorCount._totalErrorCount++;
+        builder.appendNull(fieldName);
+        return;
+    }
     builder.append(fieldName, val);
 }
 
@@ -282,54 +334,45 @@ boost::optional<BSONObj> CsvFileInput::readBsonObj() {
         return boost::none;
     }
 
+    BSONObjBuilder builder;
     auto data = parseLine(record);
+
+    // If data and metadata have different number of fields,just process as many fields as
+    // possible.
     if (data.size() != _metadata.size()) {
-        LOGV2_WARNING(200000407,
-                      "Metadata specifies {n1} fields but current record has {n2}",
-                      "n1"_attr = _metadata.size(),
-                      "n2"_attr = data.size());
+        _errorCount._metadataAndDataDifferentLength++;
+        _errorCount._totalErrorCount++;
     }
 
-    // Just process as many fields as possible
     size_t processableFields = std::min(data.size(), _metadata.size());
-
-    BSONObjBuilder builder;
-
     for (size_t i = 0; i < processableFields; ++i) {
         if (data[i] == "") {
             builder.appendNull(_metadata[i].fieldName);
             continue;
         }
 
-        try {
-            switch (_metadata[i].fieldType) {
-                case CsvFieldType::kInt32:
-                    appendTo<CsvFieldType::kInt32>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-                case CsvFieldType::kDouble:
-                    appendTo<CsvFieldType::kDouble>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-                case CsvFieldType::kInt64:
-                    appendTo<CsvFieldType::kInt64>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-                case CsvFieldType::kString:
-                    appendTo<CsvFieldType::kString>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-                case CsvFieldType::kBool:
-                    appendTo<CsvFieldType::kBool>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-                case CsvFieldType::kOid:
-                    appendTo<CsvFieldType::kOid>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-                case CsvFieldType::kDate:
-                    appendTo<CsvFieldType::kDate>(builder, _metadata[i].fieldName, data[i]);
-                    break;
-            }
-            // Catching failed conversion to stoi, stoll, and stod.
-        } catch (const std::invalid_argument& e) {
-            uasserted(ErrorCodes::BadValue, "{}: {}"_format(e.what(), data[i]));
-        } catch (const std::out_of_range& e) {
-            uasserted(ErrorCodes::Overflow, "{}: {}"_format(e.what(), data[i]));
+        switch (_metadata[i].fieldType) {
+            case CsvFieldType::kInt32:
+                appendTo<CsvFieldType::kInt32>(builder, _metadata[i].fieldName, data[i]);
+                break;
+            case CsvFieldType::kDouble:
+                appendTo<CsvFieldType::kDouble>(builder, _metadata[i].fieldName, data[i]);
+                break;
+            case CsvFieldType::kInt64:
+                appendTo<CsvFieldType::kInt64>(builder, _metadata[i].fieldName, data[i]);
+                break;
+            case CsvFieldType::kString:
+                appendTo<CsvFieldType::kString>(builder, _metadata[i].fieldName, data[i]);
+                break;
+            case CsvFieldType::kBool:
+                appendTo<CsvFieldType::kBool>(builder, _metadata[i].fieldName, data[i]);
+                break;
+            case CsvFieldType::kOid:
+                appendTo<CsvFieldType::kOid>(builder, _metadata[i].fieldName, data[i]);
+                break;
+            case CsvFieldType::kDate:
+                appendTo<CsvFieldType::kDate>(builder, _metadata[i].fieldName, data[i]);
+                break;
         }
     }
     return builder.done().getOwned();
@@ -357,6 +400,10 @@ std::vector<std::string> CsvFileInput::parseLine(const std::string& line) {
         i++;
     }
     return strs;
+}
+
+mongo::ErrorCount CsvFileInput::getStats() const {
+    return _errorCount;
 }
 
 }  // namespace mongo

--- a/src/mongo/db/storage/csv_file.h
+++ b/src/mongo/db/storage/csv_file.h
@@ -51,15 +51,17 @@ using Metadata = std::vector<FieldInfo>;
 class CsvFileInput : public StreamableInput {
 public:
     CsvFileInput(const std::string& fileRelativePath, const std::string& metadataRelativePath);
+    CsvFileInput(std::shared_ptr<InputStreamStats> stats,
+                 const std::string& fileRelativePath,
+                 const std::string& metadataRelativePath);
+
     ~CsvFileInput() override;
     const std::string& getAbsolutePath() const override {
         return _fileAbsolutePath;
     }
 
-    // Sometimes CsvFileInput can fail to read the data due to discrepancy between metadata and
-    // actual data(Ex: String data at int32 field). GetStats returns ErrorCount object that
-    // summarizes how many times each kind of error has occured during the read.
-    ErrorCount getStats() const;
+    // Factory function to denote initial ErrorCount with 0 errors.
+    static std::shared_ptr<ErrorCount> createStats();
 
     bool isOpen() const override;
     bool isGood() const override;
@@ -105,7 +107,7 @@ private:
     std::string _metadataAbsolutePath;
     std::ifstream _ifs;
     Metadata _metadata;
-    ErrorCount _errorCount;
+    ErrorCount* _errorStats;
 };
 
 }  // namespace mongo

--- a/src/mongo/db/storage/csv_file.h
+++ b/src/mongo/db/storage/csv_file.h
@@ -51,18 +51,15 @@ using Metadata = std::vector<FieldInfo>;
 class CsvFileInput : public StreamableInput {
 public:
     CsvFileInput(const std::string& fileRelativePath, const std::string& metadataRelativePath);
-    CsvFileInput(const std::string& fileRelativePath,
-                 const std::string& metadataRelativePath,
-                 const bool& strict,
-                 const size_t& threshold);
     ~CsvFileInput() override;
     const std::string& getAbsolutePath() const override {
         return _fileAbsolutePath;
     }
 
-    // Returns ErrorCount object that summarizes the errors that occured during reading in the csv
-    // file.
-    mongo::ErrorCount getStats() const;
+    // Sometimes CsvFileInput can fail to read the data due to discrepancy between metadata and
+    // actual data(Ex: String data at int32 field). GetStats returns ErrorCount object that
+    // summarizes how many times each kind of error has occured during the read.
+    ErrorCount getStats() const;
 
     bool isOpen() const override;
     bool isGood() const override;

--- a/src/mongo/db/storage/csv_file.h
+++ b/src/mongo/db/storage/csv_file.h
@@ -50,7 +50,6 @@ using Metadata = std::vector<FieldInfo>;
 
 class CsvFileInput : public StreamableInput {
 public:
-    CsvFileInput(const std::string& fileRelativePath, const std::string& metadataRelativePath);
     CsvFileInput(std::shared_ptr<InputStreamStats> stats,
                  const std::string& fileRelativePath,
                  const std::string& metadataRelativePath);
@@ -60,7 +59,7 @@ public:
         return _fileAbsolutePath;
     }
 
-    // Factory function to denote initial ErrorCount with 0 errors.
+    // Factory function to create an initial ErrorCount with 0 errors.
     static std::shared_ptr<ErrorCount> createStats();
 
     bool isOpen() const override;

--- a/src/mongo/db/storage/csv_file_test.cpp
+++ b/src/mongo/db/storage/csv_file_test.cpp
@@ -266,7 +266,7 @@ TEST_F(CsvFileInputTest, CsvBasicRead) {
     input.open();
     ASSERT_TRUE(input.isOpen());
 
-    int bufSize = 200;
+    constexpr int bufSize = 200;
     char buf[bufSize];
     int nRead = 0;
     int line = 0;
@@ -393,7 +393,7 @@ TEST_F(CsvFileInputTest, AbsentField) {
     CsvFileInput input("csv_test/absentField.csv", "csv_test/absentField.txt");
     input.open();
 
-    int bufSize = 250;
+    constexpr int bufSize = 250;
     char buf[bufSize];
 
     for (int i = 0; i < 11; i++) {
@@ -405,10 +405,11 @@ TEST_F(CsvFileInputTest, AbsentField) {
 }
 
 TEST_F(CsvFileInputTest, CollectInvalidOID) {
-    CsvFileInput invalidOid("csv_test/badOid.csv", "csv_test/badOid.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput invalidOid(errorStats, "csv_test/badOid.csv", "csv_test/badOid.txt");
     invalidOid.open();
 
-    int bufSize = 100;
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     while (!invalidOid.isEof()) {
@@ -416,17 +417,20 @@ TEST_F(CsvFileInputTest, CollectInvalidOID) {
     }
     invalidOid.close();
 
-    auto errorStatus = invalidOid.getStats();
-    ASSERT_EQ(errorStatus._invalidOid, 13);
-    ASSERT_EQ(errorStatus._invalidInt32, 14);
-    ASSERT_EQ(errorStatus._invalidDate, 14);
-    ASSERT_EQ(errorStatus._totalErrorCount, 41);
+    auto errorStatus = errorStats;
+    ASSERT_NE(errorStatus, nullptr);
+    ASSERT_EQ(errorStatus->_invalidOid, 13);
+    ASSERT_EQ(errorStatus->_invalidInt32, 14);
+    ASSERT_EQ(errorStatus->_invalidDate, 14);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 41);
 }
 
 TEST_F(CsvFileInputTest, CollectInvalidInt32) {
-    CsvFileInput invalidInt32("csv_test/badInt.csv", "csv_test/badInt.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput invalidInt32(errorStats, "csv_test/badInt.csv", "csv_test/badInt.txt");
     invalidInt32.open();
-    int bufSize = 25;
+
+    constexpr int bufSize = 25;
     char buf[bufSize];
 
     while (!invalidInt32.isEof()) {
@@ -434,15 +438,17 @@ TEST_F(CsvFileInputTest, CollectInvalidInt32) {
     }
     invalidInt32.close();
 
-    auto errorStatus = invalidInt32.getStats();
-    ASSERT_EQ(errorStatus._invalidInt32, 6);
-    ASSERT_EQ(errorStatus._totalErrorCount, 6);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_invalidInt32, 6);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 6);
 }
 
 TEST_F(CsvFileInputTest, CollectInvalidDate) {
-    CsvFileInput invalidDate("csv_test/badDate.csv", "csv_test/badDate.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput invalidDate(errorStats, "csv_test/badDate.csv", "csv_test/badDate.txt");
     invalidDate.open();
-    int bufSize = 100;
+
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     while (!invalidDate.isEof()) {
@@ -450,15 +456,17 @@ TEST_F(CsvFileInputTest, CollectInvalidDate) {
     }
     invalidDate.close();
 
-    auto errorStatus = invalidDate.getStats();
-    ASSERT_EQ(errorStatus._invalidDate, 4);
-    ASSERT_EQ(errorStatus._totalErrorCount, 4);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_invalidDate, 4);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 4);
 }
 
 TEST_F(CsvFileInputTest, CollectInvalidInt64) {
-    CsvFileInput invalidInt64("csv_test/badLong.csv", "csv_test/badLong.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput invalidInt64(errorStats, "csv_test/badLong.csv", "csv_test/badLong.txt");
     invalidInt64.open();
-    int bufSize = 100;
+
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     while (!invalidInt64.isEof()) {
@@ -466,15 +474,17 @@ TEST_F(CsvFileInputTest, CollectInvalidInt64) {
     }
     invalidInt64.close();
 
-    auto errorStatus = invalidInt64.getStats();
-    ASSERT_EQ(errorStatus._invalidInt64, 5);
-    ASSERT_EQ(errorStatus._totalErrorCount, 5);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_invalidInt64, 5);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 5);
 }
 
 TEST_F(CsvFileInputTest, CollectInvalidBoolean) {
-    CsvFileInput invalidBoolean("csv_test/badBoolean.csv", "csv_test/badBoolean.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput invalidBoolean(errorStats, "csv_test/badBoolean.csv", "csv_test/badBoolean.txt");
     invalidBoolean.open();
-    int bufSize = 100;
+
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     while (!invalidBoolean.isEof()) {
@@ -482,15 +492,17 @@ TEST_F(CsvFileInputTest, CollectInvalidBoolean) {
     }
     invalidBoolean.close();
 
-    auto errorStatus = invalidBoolean.getStats();
-    ASSERT_EQ(errorStatus._invalidBoolean, 11);
-    ASSERT_EQ(errorStatus._totalErrorCount, 11);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_invalidBoolean, 11);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 11);
 }
 
 TEST_F(CsvFileInputTest, CollectInvalidDouble) {
-    CsvFileInput invalidDouble("csv_test/badDecimal.csv", "csv_test/badDecimal.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput invalidDouble(errorStats, "csv_test/badDecimal.csv", "csv_test/badDecimal.txt");
     invalidDouble.open();
-    int bufSize = 100;
+
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     while (!invalidDouble.isEof()) {
@@ -498,15 +510,18 @@ TEST_F(CsvFileInputTest, CollectInvalidDouble) {
     }
     invalidDouble.close();
 
-    auto errorStatus = invalidDouble.getStats();
-    ASSERT_EQ(errorStatus._invalidDouble, 4);
-    ASSERT_EQ(errorStatus._totalErrorCount, 4);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_invalidDouble, 4);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 4);
 }
 
 TEST_F(CsvFileInputTest, CollectOutOfRange) {
-    CsvFileInput int32OutOfRange("csv_test/intOutOfRange.csv", "csv_test/intOutOfRange.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput int32OutOfRange(
+        errorStats, "csv_test/intOutOfRange.csv", "csv_test/intOutOfRange.txt");
     int32OutOfRange.open();
-    int bufSize = 100;
+
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     while (!int32OutOfRange.isEof()) {
@@ -514,11 +529,13 @@ TEST_F(CsvFileInputTest, CollectOutOfRange) {
     }
     int32OutOfRange.close();
 
-    auto errorStatus = int32OutOfRange.getStats();
-    ASSERT_EQ(errorStatus._outOfRange, 6);
-    ASSERT_EQ(errorStatus._totalErrorCount, 6);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_outOfRange, 6);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 6);
 
-    CsvFileInput int64OutOfRange("csv_test/longOutOfRange.csv", "csv_test/longOutOfRange.txt");
+    std::shared_ptr<ErrorCount> errorStats2 = CsvFileInput::createStats();
+    CsvFileInput int64OutOfRange(
+        errorStats2, "csv_test/longOutOfRange.csv", "csv_test/longOutOfRange.txt");
     int64OutOfRange.open();
 
     while (!int64OutOfRange.isEof()) {
@@ -526,9 +543,9 @@ TEST_F(CsvFileInputTest, CollectOutOfRange) {
     }
     int64OutOfRange.close();
 
-    auto errorStatus2 = int64OutOfRange.getStats();
-    ASSERT_EQ(errorStatus2._outOfRange, 8);
-    ASSERT_EQ(errorStatus2._totalErrorCount, 8);
+    std::shared_ptr<ErrorCount> errorStatus2(errorStats2);
+    ASSERT_EQ(errorStatus2->_outOfRange, 8);
+    ASSERT_EQ(errorStatus2->_totalErrorCount, 8);
 }
 
 TEST_F(CsvFileInputTest, FailByFileDoesNotExist) {
@@ -570,7 +587,8 @@ TEST_F(CsvFileInputTest, FailByBadMetadata) {
 }
 
 TEST_F(CsvFileInputTest, ErrorCount) {
-    CsvFileInput input("csv_test/errorCount.csv", "csv_test/errorCount.txt");
+    std::shared_ptr<ErrorCount> errorStats = CsvFileInput::createStats();
+    CsvFileInput input(errorStats, "csv_test/errorCount.csv", "csv_test/errorCount.txt");
     input.open();
 
     std::vector expected = {
@@ -664,24 +682,24 @@ TEST_F(CsvFileInputTest, ErrorCount) {
     RightOrWrong: true
 })")};
 
-    int bufSize = 200;
+    constexpr int bufSize = 200;
     char buf[bufSize];
     for (const BSONObj& expect : expected) {
         input.read(buf, bufSize);
         ASSERT_BSONOBJ_EQ(BSONObj(buf), expect);
     }
 
-    auto errorStats = input.getStats();
-    ASSERT_EQ(errorStats._incompleteConversionToNumeric, 4);
-    ASSERT_EQ(errorStats._invalidInt32, 1);
-    ASSERT_EQ(errorStats._invalidInt64, 1);
-    ASSERT_EQ(errorStats._invalidDouble, 2);
-    ASSERT_EQ(errorStats._outOfRange, 4);
-    ASSERT_EQ(errorStats._invalidDate, 6);
-    ASSERT_EQ(errorStats._invalidOid, 5);
-    ASSERT_EQ(errorStats._invalidBoolean, 4);
-    ASSERT_EQ(errorStats._nonCompliantWithMetadata, 1);
-    ASSERT_EQ(errorStats._totalErrorCount, 28);
+    std::shared_ptr<ErrorCount> errorStatus(errorStats);
+    ASSERT_EQ(errorStatus->_incompleteConversionToNumeric, 4);
+    ASSERT_EQ(errorStatus->_invalidInt32, 1);
+    ASSERT_EQ(errorStatus->_invalidInt64, 1);
+    ASSERT_EQ(errorStatus->_invalidDouble, 2);
+    ASSERT_EQ(errorStatus->_outOfRange, 4);
+    ASSERT_EQ(errorStatus->_invalidDate, 6);
+    ASSERT_EQ(errorStatus->_invalidOid, 5);
+    ASSERT_EQ(errorStatus->_invalidBoolean, 4);
+    ASSERT_EQ(errorStatus->_nonCompliantWithMetadata, 1);
+    ASSERT_EQ(errorStatus->_totalErrorCount, 28);
 
     input.close();
 }
@@ -708,7 +726,7 @@ TEST_F(CsvFileInputTest, SpecialNumericCase) {
         fromjson(R"({ stodSpecial: 9.024434 })"),
         fromjson(R"({ stodSpecial: nan })")};
 
-    int bufSize = 100;
+    constexpr int bufSize = 100;
     char buf[bufSize];
 
     for (int i = 0; i < 14; i++) {

--- a/src/mongo/db/storage/csv_file_test.cpp
+++ b/src/mongo/db/storage/csv_file_test.cpp
@@ -17,7 +17,8 @@ protected:
 };
 
 TEST_F(CsvFileInputTest, CsvBasicRead) {
-    CsvFileInput input("csv_test/basicRead.csv", "csv_test/basicRead.txt");
+    auto dummyStats = std::make_shared<ErrorCount>();
+    CsvFileInput input(dummyStats, "csv_test/basicRead.csv", "csv_test/basicRead.txt");
 
     std::vector expected = {
 
@@ -390,7 +391,8 @@ TEST_F(CsvFileInputTest, AbsentField) {
     correct: false
 })")};
 
-    CsvFileInput input("csv_test/absentField.csv", "csv_test/absentField.txt");
+    auto dummyStats = std::make_shared<ErrorCount>();
+    CsvFileInput input(dummyStats, "csv_test/absentField.csv", "csv_test/absentField.txt");
     input.open();
 
     constexpr int bufSize = 250;
@@ -549,40 +551,48 @@ TEST_F(CsvFileInputTest, CollectOutOfRange) {
 }
 
 TEST_F(CsvFileInputTest, FailByFileDoesNotExist) {
-    CsvFileInput input("DNE.csv", "DNE.txt");
+    auto dummyStats = std::make_shared<ErrorCount>();
+
+    CsvFileInput input(dummyStats, "DNE.csv", "DNE.txt");
     ASSERT_THROWS_CODE(input.open(), DBException, ErrorCodes::FileNotOpen);
 
-    CsvFileInput input1("DNE1.csv", "DNE1.txt");
+    CsvFileInput input1(dummyStats, "DNE1.csv", "DNE1.txt");
     ASSERT_THROWS_CODE(input1.open(), DBException, ErrorCodes::FileNotOpen);
 
-    CsvFileInput input2("DNE2.csv", "csv_test/badOid.txt");
+    CsvFileInput input2(dummyStats, "DNE2.csv", "csv_test/badOid.txt");
     ASSERT_THROWS_CODE(input2.open(), DBException, ErrorCodes::FileNotOpen);
 }
 
 TEST_F(CsvFileInputTest, FailByBadFilePathFormat) {
-    ASSERT_THROWS_CODE(
-        CsvFileInput("../diffLength.csv", "../csv_test/diffLength.txt"), DBException, 200000400);
+    auto dummyStats = std::make_shared<ErrorCount>();
+    ASSERT_THROWS_CODE(CsvFileInput(dummyStats, "../diffLength.csv", "../csv_test/diffLength.txt"),
+                       DBException,
+                       200000400);
 
-    ASSERT_THROWS_CODE(CsvFileInput("../DNE1.csv", "../DNE1.txt"), DBException, 200000400);
+    ASSERT_THROWS_CODE(
+        CsvFileInput(dummyStats, "../DNE1.csv", "../DNE1.txt"), DBException, 200000400);
 
     ASSERT_THROWS_CODE(
-        CsvFileInput("basicRead.csv",
+        CsvFileInput(dummyStats,
+                     "basicRead.csv",
                      "../Users/youngjoonkim/mongo/src/mongo/db/storage/csv_test /tmp/"),
         DBException,
         200000401);
 }
 
 TEST_F(CsvFileInputTest, FailByBadMetadata) {
-    CsvFileInput input("csv_test/badMetadata.csv", "csv_test/badMetadata.txt");
+    auto dummyStats = std::make_shared<ErrorCount>();
+
+    CsvFileInput input(dummyStats, "csv_test/badMetadata.csv", "csv_test/badMetadata.txt");
     ASSERT_THROWS_CODE(input.open(), DBException, 200000403);
 
-    CsvFileInput input1("csv_test/badMetadata.csv", "csv_test/badMetadata1.txt");
+    CsvFileInput input1(dummyStats, "csv_test/badMetadata.csv", "csv_test/badMetadata1.txt");
     ASSERT_THROWS_CODE(input1.open(), DBException, 200000403);
 
-    CsvFileInput input2("csv_test/badMetadata.csv", "csv_test/badMetadata2.txt");
+    CsvFileInput input2(dummyStats, "csv_test/badMetadata.csv", "csv_test/badMetadata2.txt");
     ASSERT_THROWS_CODE(input2.open(), DBException, 200000404);
 
-    CsvFileInput input3("csv_test/badMetadata.csv", "csv_test/badMetadata3.txt");
+    CsvFileInput input3(dummyStats, "csv_test/badMetadata.csv", "csv_test/badMetadata3.txt");
     ASSERT_THROWS_CODE(input3.open(), DBException, 200000403);
 }
 
@@ -705,7 +715,8 @@ TEST_F(CsvFileInputTest, ErrorCount) {
 }
 
 TEST_F(CsvFileInputTest, SpecialNumericCase) {
-    CsvFileInput input("csv_test/specialNumeric.csv", "csv_test/specialNumeric.txt");
+    auto dummyStats = std::make_shared<ErrorCount>();
+    CsvFileInput input(dummyStats, "csv_test/specialNumeric.csv", "csv_test/specialNumeric.txt");
     input.open();
 
     std::vector expected = {

--- a/src/mongo/db/storage/csv_test/errorCount.csv
+++ b/src/mongo/db/storage/csv_test/errorCount.csv
@@ -1,0 +1,9 @@
+string,number,long,double,boolean,oid,date
+holyMoly,34,1234567890,35.23,true,123456789012345678901234,2024-04-12T13:36:37.100-06:00
+Christopher Columbus,48,12345678901.2334,48.12,!true,objectid(123456789123456789),2024-04-11T13:34:34.343Z
+Backpack,55.12,33.33,45,incorrect,objectID("1029384756abcdeabcde"),2024-11-11T36:34:63.342Z
+Cannot,3000000000,99000000000000000000,33.4,true,"123456789123456789abcdef,2014-14-14
+smoking Hot,34,12345678901,GGang,boolean,"objectIDobjectIdobjectId",Not A Date Bro
+,-2900000000,-9323372036854775808,90.09,f,objectID("You think this is ID"),201708081111111Z
+Really Really Really Really Really Long String I mean Really Really Long,3,45,1.2,FALSE,objectid("884cdc3ef43ff10ca56e23fd"),Rizz
+Strong and Sound,23Catalog,9000000000,1345.232,yes

--- a/src/mongo/db/storage/csv_test/errorCount.txt
+++ b/src/mongo/db/storage/csv_test/errorCount.txt
@@ -1,0 +1,1 @@
+kString/string,number/int32,distant/int64,quadruple/double,RightOrWrong/bool,identifier/oid,signOn/date

--- a/src/mongo/db/storage/csv_test/specialNumeric.csv
+++ b/src/mongo/db/storage/csv_test/specialNumeric.csv
@@ -1,0 +1,14 @@
+nan
+NAN
+-NAN
+nAN
+INF
+infp
+infinity
+INFINITY
+-INF
+-inF
+4.5123e+10
+6634e-3
+6.71134E+12
+9024434E-6

--- a/src/mongo/db/storage/csv_test/specialNumeric.txt
+++ b/src/mongo/db/storage/csv_test/specialNumeric.txt
@@ -1,0 +1,1 @@
+stodSpecial/double

--- a/src/mongo/db/storage/error_count.h
+++ b/src/mongo/db/storage/error_count.h
@@ -29,10 +29,11 @@
 
 #pragma once
 
+#include "mongo/db/storage/input_stream.h"
 #include <cstdint>
 
 namespace mongo {
-struct ErrorCount {
+struct ErrorCount : public InputStreamStats {
     // Variables to keep track of the count of errors occured during reading csv file.
     int64_t _incompleteConversionToNumeric = 0;
     int64_t _invalidInt32 = 0;
@@ -44,6 +45,21 @@ struct ErrorCount {
     int64_t _invalidBoolean = 0;
     int64_t _nonCompliantWithMetadata = 0;
     int64_t _totalErrorCount = 0;
+
+    boost::optional<BSONObj> toBson() const override {
+        BSONObjBuilder builder;
+        builder.append("incompleteConversionToNumeric", _incompleteConversionToNumeric);
+        builder.append("invalidInt32", _invalidInt32);
+        builder.append("invalidInt64", _invalidInt64);
+        builder.append("invalidDouble", _invalidDouble);
+        builder.append("outOfRange", _outOfRange);
+        builder.append("invalidDate", _invalidDate);
+        builder.append("invalidOid", _invalidOid);
+        builder.append("invalidBoolean", _invalidBoolean);
+        builder.append("metadataAndDataDifferentLength", _nonCompliantWithMetadata);
+        builder.append("totalErrorCount", _totalErrorCount);
+        return builder.done().getOwned();
+    }
 
     ErrorCount operator+(const ErrorCount& other) const {
         ErrorCount ret(*this);

--- a/src/mongo/db/storage/error_count.h
+++ b/src/mongo/db/storage/error_count.h
@@ -1,3 +1,32 @@
+/**
+ *    Copyright (C) 2024-present Codein, Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the Server Side Public License, version 1,
+ *    as published by MongoDB, Inc.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    Server Side Public License for more details.
+ *
+ *    You should have received a copy of the Server Side Public License
+ *    along with this program. If not, see
+ *    <http://www.mongodb.com/licensing/server-side-public-license>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the Server Side Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
 #pragma once
 
 #include <cstdint>
@@ -5,46 +34,79 @@
 namespace mongo {
 struct ErrorCount {
     // Variables to keep track of the count of errors occured during reading csv file.
-    std::int64_t _incompleteConversionToNumeric = 0;
-    std::int64_t _invalidInt32 = 0;
-    std::int64_t _invalidInt64 = 0;
-    std::int64_t _invalidDouble = 0;
-    std::int64_t _outOfRange = 0;
-    std::int64_t _invalidDate = 0;
-    std::int64_t _invalidOid = 0;
-    std::int64_t _invalidBoolean = 0;
-    std::int64_t _metadataAndDataDifferentLength = 0;
-    std::int64_t _totalErrorCount = 0;
+    int64_t _incompleteConversionToNumeric = 0;
+    int64_t _invalidInt32 = 0;
+    int64_t _invalidInt64 = 0;
+    int64_t _invalidDouble = 0;
+    int64_t _outOfRange = 0;
+    int64_t _invalidDate = 0;
+    int64_t _invalidOid = 0;
+    int64_t _invalidBoolean = 0;
+    int64_t _nonCompliantWithMetadata = 0;
+    int64_t _totalErrorCount = 0;
 
     ErrorCount operator+(const ErrorCount& other) const {
-        ErrorCount ret;
-        ret._incompleteConversionToNumeric =
-            this->_incompleteConversionToNumeric + other._incompleteConversionToNumeric;
-        ret._invalidInt32 = this->_invalidInt32 + other._invalidInt32;
-        ret._invalidInt64 = this->_invalidInt64 + other._invalidInt64;
-        ret._invalidDouble = this->_invalidDouble + other._invalidDouble;
-        ret._outOfRange = this->_outOfRange + other._outOfRange;
-        ret._invalidDate = this->_invalidDate + other._invalidDate;
-        ret._invalidBoolean = this->_invalidBoolean + other._invalidBoolean;
-        ret._invalidOid = this->_invalidOid + other._invalidOid;
-        ret._metadataAndDataDifferentLength =
-            this->_metadataAndDataDifferentLength + other._metadataAndDataDifferentLength;
-        ret._totalErrorCount = this->_totalErrorCount + other._totalErrorCount;
-        return ret;
+        ErrorCount ret(*this);
+        return ret += other;
     }
 
     ErrorCount& operator+=(const ErrorCount& other) {
-        this->_incompleteConversionToNumeric += other._incompleteConversionToNumeric;
-        this->_invalidInt32 += other._invalidInt32;
-        this->_invalidInt64 += other._invalidInt64;
-        this->_invalidDouble += other._invalidDouble;
-        this->_invalidBoolean += other._invalidBoolean;
-        this->_invalidDate += other._invalidDate;
-        this->_invalidOid += other._invalidOid;
-        this->_outOfRange += other._outOfRange;
-        this->_metadataAndDataDifferentLength += other._metadataAndDataDifferentLength;
-        this->_totalErrorCount += other._totalErrorCount;
+        _incompleteConversionToNumeric += other._incompleteConversionToNumeric;
+        _invalidInt32 += other._invalidInt32;
+        _invalidInt64 += other._invalidInt64;
+        _invalidDouble += other._invalidDouble;
+        _invalidBoolean += other._invalidBoolean;
+        _invalidDate += other._invalidDate;
+        _invalidOid += other._invalidOid;
+        _outOfRange += other._outOfRange;
+        _nonCompliantWithMetadata += other._nonCompliantWithMetadata;
+        _totalErrorCount += other._totalErrorCount;
         return *this;
+    }
+
+    void incIncompleteConversionToNumeric() {
+        _incompleteConversionToNumeric++;
+        _totalErrorCount++;
+    }
+
+    void incInvalidInt32() {
+        _invalidInt32++;
+        _totalErrorCount++;
+    }
+
+    void incInvalidInt64() {
+        _invalidInt64++;
+        _totalErrorCount++;
+    }
+
+    void incInvalidDouble() {
+        _invalidDouble++;
+        _totalErrorCount++;
+    }
+
+    void incInvalidBoolean() {
+        _invalidBoolean++;
+        _totalErrorCount++;
+    }
+
+    void incInvalidOid() {
+        _invalidOid++;
+        _totalErrorCount++;
+    }
+
+    void incInvalidDate() {
+        _invalidDate++;
+        _totalErrorCount++;
+    }
+
+    void incNonCompliantWithMetadata() {
+        _nonCompliantWithMetadata++;
+        _totalErrorCount++;
+    }
+
+    void incOutOfRange() {
+        _outOfRange++;
+        _totalErrorCount++;
     }
 };
 }  // namespace mongo

--- a/src/mongo/db/storage/error_count.h
+++ b/src/mongo/db/storage/error_count.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+namespace mongo {
+struct ErrorCount {
+    // Variables to keep track of the count of errors occured during reading csv file.
+    std::int64_t _incompleteConversionToNumeric = 0;
+    std::int64_t _invalidInt32 = 0;
+    std::int64_t _invalidInt64 = 0;
+    std::int64_t _invalidDouble = 0;
+    std::int64_t _outOfRange = 0;
+    std::int64_t _invalidDate = 0;
+    std::int64_t _invalidOid = 0;
+    std::int64_t _invalidBoolean = 0;
+    std::int64_t _metadataAndDataDifferentLength = 0;
+    std::int64_t _totalErrorCount = 0;
+
+    ErrorCount operator+(const ErrorCount& other) const {
+        ErrorCount ret;
+        ret._incompleteConversionToNumeric =
+            this->_incompleteConversionToNumeric + other._incompleteConversionToNumeric;
+        ret._invalidInt32 = this->_invalidInt32 + other._invalidInt32;
+        ret._invalidInt64 = this->_invalidInt64 + other._invalidInt64;
+        ret._invalidDouble = this->_invalidDouble + other._invalidDouble;
+        ret._outOfRange = this->_outOfRange + other._outOfRange;
+        ret._invalidDate = this->_invalidDate + other._invalidDate;
+        ret._invalidBoolean = this->_invalidBoolean + other._invalidBoolean;
+        ret._invalidOid = this->_invalidOid + other._invalidOid;
+        ret._metadataAndDataDifferentLength =
+            this->_metadataAndDataDifferentLength + other._metadataAndDataDifferentLength;
+        ret._totalErrorCount = this->_totalErrorCount + other._totalErrorCount;
+        return ret;
+    }
+
+    ErrorCount& operator+=(const ErrorCount& other) {
+        this->_incompleteConversionToNumeric += other._incompleteConversionToNumeric;
+        this->_invalidInt32 += other._invalidInt32;
+        this->_invalidInt64 += other._invalidInt64;
+        this->_invalidDouble += other._invalidDouble;
+        this->_invalidBoolean += other._invalidBoolean;
+        this->_invalidDate += other._invalidDate;
+        this->_invalidOid += other._invalidOid;
+        this->_outOfRange += other._outOfRange;
+        this->_metadataAndDataDifferentLength += other._metadataAndDataDifferentLength;
+        this->_totalErrorCount += other._totalErrorCount;
+        return *this;
+    }
+};
+}  // namespace mongo

--- a/src/mongo/db/storage/input_stream.h
+++ b/src/mongo/db/storage/input_stream.h
@@ -58,7 +58,10 @@ public:
      */
     virtual int readBytes(int count, char* buffer) = 0;
 
-    virtual mongo::ErrorCount getStats() const = 0;
+    /**
+     * Collect occurrences of errors that occurred while reading the external inputStream
+     */
+    virtual ErrorCount getStats() const = 0;
 
     virtual ~InputStream() {}
 };
@@ -92,7 +95,7 @@ public:
 
     ~InputStreamImpl() override = default;
 
-    mongo::ErrorCount getStats() const override {
+    ErrorCount getStats() const override {
         return InputT::getStats();
     }
 

--- a/src/mongo/db/storage/input_stream.h
+++ b/src/mongo/db/storage/input_stream.h
@@ -32,6 +32,7 @@
 #include <fmt/format.h>
 #include <utility>
 
+#include "mongo/db/storage/error_count.h"
 #include "mongo/db/storage/io_error_message.h"
 #include "mongo/logv2/log.h"
 
@@ -56,6 +57,8 @@ public:
      * May throw an exception when count < 0.
      */
     virtual int readBytes(int count, char* buffer) = 0;
+
+    virtual mongo::ErrorCount getStats() const = 0;
 
     virtual ~InputStream() {}
 };
@@ -88,6 +91,10 @@ public:
     }
 
     ~InputStreamImpl() override = default;
+
+    mongo::ErrorCount getStats() const override {
+        return InputT::getStats();
+    }
 
     int readBytes(int count, char* buffer) override {
         tassert(7005000, "Number of bytes to read must be greater than 0", count > 0);

--- a/src/mongo/db/storage/multi_bson_stream_cursor.cpp
+++ b/src/mongo/db/storage/multi_bson_stream_cursor.cpp
@@ -232,7 +232,7 @@ boost::optional<BSONObj> MultiBsonStreamCursor::getStats() const {
     builder.append("invalidDate", curErrorStats._invalidDate);
     builder.append("invalidOid", curErrorStats._invalidOid);
     builder.append("invalidBoolean", curErrorStats._invalidBoolean);
-    builder.append("metadataAndDataDifferentLength", curErrorStats._metadataAndDataDifferentLength);
+    builder.append("metadataAndDataDifferentLength", curErrorStats._nonCompliantWithMetadata);
     builder.append("totalErrorCount", curErrorStats._totalErrorCount);
     return builder.done().getOwned();
 }

--- a/src/mongo/db/storage/multi_bson_stream_cursor.h
+++ b/src/mongo/db/storage/multi_bson_stream_cursor.h
@@ -39,7 +39,6 @@
 #include <boost/optional/optional.hpp>
 #include <fmt/format.h>
 
-#include "error_count.h"
 #include "mongo/db/catalog/external_data_source_options_gen.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/record_id.h"
@@ -50,12 +49,7 @@
 namespace mongo {
 class MultiBsonStreamCursor : public SeekableRecordCursor {
 public:
-    MultiBsonStreamCursor(const VirtualCollectionOptions& vopts)
-        : _numStreams(vopts.getDataSources().size()), _vopts(vopts) {
-        using namespace fmt::literals;
-        tassert(6968310, "_numStreams {} <= 0"_format(_numStreams), _numStreams > 0);
-        _streamReader = getInputStream();
-    }
+    MultiBsonStreamCursor(const VirtualCollectionOptions& vopts);
 
     boost::optional<Record> next() override;
 
@@ -121,6 +115,6 @@ private:
 
     const VirtualCollectionOptions& _vopts;  // metadata containing the pipe URLs
 
-    ErrorCount _errorStats = ErrorCount();
+    std::shared_ptr<InputStreamStats> _stats;
 };
 }  // namespace mongo

--- a/src/mongo/db/storage/multi_bson_stream_cursor.h
+++ b/src/mongo/db/storage/multi_bson_stream_cursor.h
@@ -121,6 +121,6 @@ private:
 
     const VirtualCollectionOptions& _vopts;  // metadata containing the pipe URLs
 
-    mongo::ErrorCount _errorStats = ErrorCount();
+    ErrorCount _errorStats = ErrorCount();
 };
 }  // namespace mongo

--- a/src/mongo/db/storage/multi_bson_stream_cursor.h
+++ b/src/mongo/db/storage/multi_bson_stream_cursor.h
@@ -39,6 +39,7 @@
 #include <boost/optional/optional.hpp>
 #include <fmt/format.h>
 
+#include "error_count.h"
 #include "mongo/db/catalog/external_data_source_options_gen.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/record_id.h"
@@ -57,6 +58,8 @@ public:
     }
 
     boost::optional<Record> next() override;
+
+    boost::optional<BSONObj> getStats() const override;
 
     // This block of overrides are all essentially no-ops as they are for lock yielding but the
     // external data source is read-only.
@@ -117,5 +120,7 @@ private:
     std::unique_ptr<InputStream> _streamReader = nullptr;
 
     const VirtualCollectionOptions& _vopts;  // metadata containing the pipe URLs
+
+    mongo::ErrorCount _errorStats = ErrorCount();
 };
 }  // namespace mongo

--- a/src/mongo/db/storage/named_pipe.h
+++ b/src/mongo/db/storage/named_pipe.h
@@ -81,11 +81,6 @@ public:
     bool isFailed() const override;
     bool isEof() const override;
 
-    // Nothing to return
-    ErrorCount getStats() const {
-        return ErrorCount();
-    }
-
 protected:
     void doOpen() override;
     int doRead(char* data, int size) override;

--- a/src/mongo/db/storage/named_pipe.h
+++ b/src/mongo/db/storage/named_pipe.h
@@ -37,7 +37,6 @@
 #include <string>
 
 #include "mongo/db/storage/default_path.h"
-#include "mongo/db/storage/error_count.h"
 #include "mongo/db/storage/input_object.h"
 
 namespace mongo {

--- a/src/mongo/db/storage/named_pipe.h
+++ b/src/mongo/db/storage/named_pipe.h
@@ -81,9 +81,8 @@ public:
     bool isFailed() const override;
     bool isEof() const override;
 
-    // without this line, ninja doesn't complain about NamedPipeInput not having this function due
-    // to input_stream.h line 95
-    mongo::ErrorCount getStats() const {
+    // Nothing to return
+    ErrorCount getStats() const {
         return ErrorCount();
     }
 

--- a/src/mongo/db/storage/named_pipe.h
+++ b/src/mongo/db/storage/named_pipe.h
@@ -37,6 +37,7 @@
 #include <string>
 
 #include "mongo/db/storage/default_path.h"
+#include "mongo/db/storage/error_count.h"
 #include "mongo/db/storage/input_object.h"
 
 namespace mongo {
@@ -79,6 +80,12 @@ public:
     bool isGood() const override;
     bool isFailed() const override;
     bool isEof() const override;
+
+    // without this line, ninja doesn't complain about NamedPipeInput not having this function due
+    // to input_stream.h line 95
+    mongo::ErrorCount getStats() const {
+        return ErrorCount();
+    }
 
 protected:
     void doOpen() override;

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -188,6 +188,10 @@ public:
      * positioned cursors across commands.
      */
     virtual void setSaveStorageCursorOnDetachFromOperationContext(bool) = 0;
+
+    virtual boost::optional<BSONObj> getStats() const {
+        return boost::none;
+    }
 };
 
 /**


### PR DESCRIPTION
Fixes codeincorp/mongo#8

Revised csv_file.cpp and csv_file.h to keep track of error count
Added ErrorCount class to record error count
Added a error_report_csv_file.js for a simple test